### PR TITLE
fixed videoframe position

### DIFF
--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -37,6 +37,10 @@
           font-size: 3.5rem;
         }
       }
+      h3.masthead-brand {
+          position: fixed;
+          display: block;
+      }
     </style>
     <!-- Custom styles for this template -->
 <link href="{{ url_for('static', filename='css/cover.css') }}" rel="stylesheet" />

--- a/control/templates/regie.html
+++ b/control/templates/regie.html
@@ -52,6 +52,20 @@
     color: orangered !important;
   }
 
+  .video-container {
+    height: 607px;
+    width: 1080px;
+    background-color: rgba(0,0,0,0.33);
+    position: fixed;
+    top: 4rem;
+  }
+
+  .regie-container {
+    top: 4rem;
+    right: 2rem;
+    position: absolute;
+  }
+
 </style>
 {% endblock %}
 
@@ -64,11 +78,11 @@
 <main role="main" class="container-fluid">
   <div class="row">
     <div class="col-md-8 video-main">
-      <div class="video-container" id="video-container" style="height:607px; width:1080px; background-color:rgba(0,0,0,0.33)">
+      <div class="video-container" id="video-container">
       </div><!-- /.video-container -->
     </div><!-- /.video-main -->
 
-    <aside id="regie-container" class="col-md-4 controls-side">
+    <aside id="regie-container" class="col-md-4 controls-side regie-container">
         <div class="p-2">
           <div class="custom-control custom-switch">
             <input type="checkbox" class="custom-control-input" id="enableControlSwitch" v-model="remote_control">


### PR DESCRIPTION
Wie in der Testsession besprochen, das Videofenster bleibt jetzt an einer statischen Position, falls man scrollen muss um an die Jits-Controlls zu kommen. Alles very hacky hacky, aber scheint in Chrome und FF zu funktionieren. 